### PR TITLE
fix: use extension-module for pyo3

### DIFF
--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -25,4 +25,4 @@ smallvec = "1.10.0"
 
 [dependencies.pyo3]
 version = "0.20.2"
-features = ["abi3-py38"]
+features = ["extension-module"]


### PR DESCRIPTION
For me, this fixed the errors on `cargo build --bin peano --release`.

@maharajamihir Can you test on your cluster whether a clean-sheet setup works without any quirks or errors?